### PR TITLE
feat: useModal 구현

### DIFF
--- a/src/components/Navigation/SearchBar.tsx
+++ b/src/components/Navigation/SearchBar.tsx
@@ -11,9 +11,9 @@ import {
 import useDebounce from '~/hooks/useDebounce'
 import { Link, useNavigate } from 'react-router-dom'
 import useGetHerbSearchList from '~/hooks/queries/useGetHerbSearchList'
-import useModal from '~/hooks/useModal'
 import boldSearchQuery from '~/utils/boldSearchQuery'
 import Spinner from '../Spinner'
+import useDropBox from '~/hooks/useDropBox'
 
 //TODO
 // 1. 추천검색어 키보드 이벤트 가능하도록
@@ -25,7 +25,7 @@ interface RecommendListItem {
 
 const SearchBar = () => {
   const [searchQuery, setSearchQuery] = useState<string>('')
-  const { modalRef, isShow, setIsShow } = useModal()
+  const { modalRef, isShow, setIsShow } = useDropBox()
   const navigate = useNavigate()
 
   const { data, isLoading } = useGetHerbSearchList(searchQuery)

--- a/src/components/Navigation/styled/index.ts
+++ b/src/components/Navigation/styled/index.ts
@@ -9,7 +9,7 @@ export const Container = styled.section`
   left: 0;
   width: 100%;
 
-  z-index: 999;
+  z-index: 10;
   @media (max-width: 360px) {
     max-width: 360px;
   }

--- a/src/hooks/useDropBox.ts
+++ b/src/hooks/useDropBox.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-const useModal = () => {
+const useDropBox = () => {
   const modalRef = useRef<HTMLUListElement | null>(null)
   const [isShow, setIsShow] = useState(false)
 
@@ -29,4 +29,4 @@ const useModal = () => {
 
   return { modalRef, isShow, setIsShow }
 }
-export default useModal
+export default useDropBox

--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -1,0 +1,38 @@
+import { ReactNode, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { ModalContent, ModalOverlay } from './styled'
+
+interface UseModalResult {
+  Modal: ({ children , isOpen, close}:ModalComponentProps) => JSX.Element
+  open: () => void
+  close: () => void
+  isOpen: boolean
+}
+interface ModalComponentProps {
+  children: ReactNode
+  isOpen: boolean
+  close: () => void
+}
+
+const ModalComponent = ({ isOpen, close, children }: ModalComponentProps) => {
+  return createPortal(
+    <>
+      <ModalOverlay
+        isOpen={isOpen}
+        onClick={close}
+      />
+      <ModalContent isOpen={isOpen}>{children}</ModalContent>
+    </>,
+    document.getElementById('root')!
+  )
+}
+
+export const useModal = (initialValue = false) :UseModalResult => {
+  const [isOpen, setOpen] = useState<boolean>(initialValue)
+
+  const open = () => setOpen(true)
+  const close = () => setOpen(false)
+
+  return { Modal: ModalComponent, open, close, isOpen }
+}
+export default useModal

--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -23,7 +23,7 @@ const ModalComponent = ({ isOpen, close, children }: ModalComponentProps) => {
       />
       <ModalContent isOpen={isOpen}>{children}</ModalContent>
     </>,
-    document.getElementById('root')!
+    document.body
   )
 }
 

--- a/src/hooks/useModal/styled/index.ts
+++ b/src/hooks/useModal/styled/index.ts
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled'
+
+interface ModalOverlayAndContentProps {
+  isOpen: boolean
+}
+
+export const ModalOverlay = styled.div<ModalOverlayAndContentProps>`
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 40;
+  transition: opacity 1s ease;
+  opacity: ${props => (props.isOpen ? 100 : 0)};
+  transform: translateX(${props => (props.isOpen ? 0 : '100vw')});
+`
+
+export const ModalContent = styled.div<ModalOverlayAndContentProps>`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 70%;
+  height: 70%;
+  margin: auto;
+  border-radius: 0.5rem;
+  background-color: white;
+  z-index: 40;
+  color: black;
+  overflow: scroll;
+  -ms-overflow-style: none;
+
+  scrollbar-width: none;
+  transform: translateY(${props => (props.isOpen ? 0 : '100vh')});
+  transition: transform 1s ease;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,27 @@
+import { Global, ThemeProvider, useTheme } from "@emotion/react";
+import useModal from "~/hooks/useModal";
+import GlobalStyle from "~/styles/GlobalStyles";
+import { default as THEME } from '~/styles/Theme'
+
+export default {
+    title: 'Common/Components/useModal',
+} 
+
+export const Default = {
+    render: function Render() {
+        const {Modal,open,close,isOpen} = useModal();
+
+    return (
+        <div>
+            <ThemeProvider theme={THEME["dark"]}>
+            <Global styles={GlobalStyle(THEME["dark"])} />
+                <button onClick={open} style={{backgroundColor:"lightblue", padding: "5px", borderRadius: "5px"}}>Modal 오픈</button>
+                <Modal isOpen={isOpen} close={close}>
+                    <div>안녕하세요</div>
+                    <div>하이하이복실</div>
+                </Modal>
+            </ThemeProvider>
+        </div>
+    )
+    }
+}

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import { Global, ThemeProvider, useTheme } from "@emotion/react";
+import { Global, ThemeProvider } from "@emotion/react";
 import useModal from "~/hooks/useModal";
 import GlobalStyle from "~/styles/GlobalStyles";
 import { default as THEME } from '~/styles/Theme'


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - close #number -->

- close #22

## ✅ 작업 내용

- useModal 구현
- 이전에 사용하던 useModal은 useDropBox로 임시변경 
 -> useDropBox도 다른 방식으로 변경 예정

https://github.com/oridori2705/Herbs-Or-weeds/assets/90139306/5f2ab1f7-5722-4d70-97c8-627b33aeb65b


### 사용방법

```
import useModal from "~/hooks/useModal";

export default function MainPage() {
  const {Modal,open,close,isOpen} = useModal();

  return <section>
    <button onClick={open}>Modal 오픈</button>
    <Modal isOpen={isOpen} close={close}>
         {/* Modal 내용 부분*/}
    </Modal>
  </section>
}
```
- useModal을 통해 더욱 간단하게 Modal 사용가능
- Reflow를 일으키지 않도록 스타일 지정
- Modal이 필요없을 때도 렌더링 때 그려지긴 하지만 이를 통해 transition 효과 사용가능

## 📝 참고 자료


## ♾️ 기타

