### PR TITLE
refactor: 조건부 렌더링 및 transition을 위한 setTimeout 추가

### DIFF
--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -17,11 +17,15 @@ interface ModalComponentProps {
   children: ReactNode
   isOpen: boolean
   isAnimating: boolean
+  width?: number
+  height?: number
   close: () => void
 }
 
 const ModalComponent = ({
   isOpen,
+  width = 70,
+  height = 70,
   isAnimating,
   close,
   children
@@ -34,7 +38,12 @@ const ModalComponent = ({
         isOpen={isAnimating}
         onClick={close}
       />
-      <ModalContent isOpen={isAnimating}>{children}</ModalContent>
+      <ModalContent
+        width={width}
+        height={height}
+        isOpen={isAnimating}>
+        {children}
+      </ModalContent>
     </>,
     document.body
   )

--- a/src/hooks/useModal/styled/index.ts
+++ b/src/hooks/useModal/styled/index.ts
@@ -4,6 +4,11 @@ interface ModalOverlayAndContentProps {
   isOpen: boolean
 }
 
+interface ModalContentProps extends ModalOverlayAndContentProps {
+  width: number
+  height: number
+}
+
 export const ModalOverlay = styled.div<ModalOverlayAndContentProps>`
   position: fixed;
   top: 0;
@@ -13,19 +18,19 @@ export const ModalOverlay = styled.div<ModalOverlayAndContentProps>`
   width: 100vw;
   height: 100vh;
   background-color: rgba(0, 0, 0, 0.5);
-  z-index: 40;
+  z-index: 50;
   transition: opacity 1s ease;
   opacity: ${props => (props.isOpen ? 0.99 : 0)};
 `
 
-export const ModalContent = styled.div<ModalOverlayAndContentProps>`
+export const ModalContent = styled.div<ModalContentProps>`
   position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
-  width: 70%;
-  height: 70%;
+  width: ${props => `${props.width}%`};
+  height: ${props => `${props.height}%`};
   margin: auto;
   border-radius: 0.5rem;
   background-color: white;

--- a/src/hooks/useModal/styled/index.ts
+++ b/src/hooks/useModal/styled/index.ts
@@ -15,8 +15,7 @@ export const ModalOverlay = styled.div<ModalOverlayAndContentProps>`
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 40;
   transition: opacity 1s ease;
-  opacity: ${props => (props.isOpen ? 100 : 0)};
-  transform: translateX(${props => (props.isOpen ? 0 : '100vw')});
+  opacity: ${props => (props.isOpen ? 0.99 : 0)};
 `
 
 export const ModalContent = styled.div<ModalOverlayAndContentProps>`
@@ -30,11 +29,10 @@ export const ModalContent = styled.div<ModalOverlayAndContentProps>`
   margin: auto;
   border-radius: 0.5rem;
   background-color: white;
-  z-index: 40;
+  z-index: 50;
   color: black;
   overflow: scroll;
   -ms-overflow-style: none;
-
   scrollbar-width: none;
   transform: translateY(${props => (props.isOpen ? 0 : '100vh')});
   transition: transform 1s ease;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,27 +1,38 @@
-import { Global, ThemeProvider } from "@emotion/react";
-import useModal from "~/hooks/useModal";
-import GlobalStyle from "~/styles/GlobalStyles";
+import { Global, ThemeProvider } from '@emotion/react'
+import useModal from '~/hooks/useModal'
+import GlobalStyle from '~/styles/GlobalStyles'
 import { default as THEME } from '~/styles/Theme'
 
 export default {
-    title: 'Common/Components/useModal',
-} 
+  title: 'Common/Components/useModal'
+}
 
 export const Default = {
-    render: function Render() {
-        const {Modal,open,close,isOpen} = useModal();
+  render: function Render() {
+    const { Modal, open, close, isOpen, isAnimating } = useModal()
 
     return (
-        <div>
-            <ThemeProvider theme={THEME["dark"]}>
-            <Global styles={GlobalStyle(THEME["dark"])} />
-                <button onClick={open} style={{backgroundColor:"lightblue", padding: "5px", borderRadius: "5px"}}>Modal 오픈</button>
-                <Modal isOpen={isOpen} close={close}>
-                    <div>안녕하세요</div>
-                    <div>하이하이복실</div>
-                </Modal>
-            </ThemeProvider>
-        </div>
+      <div>
+        <ThemeProvider theme={THEME['dark']}>
+          <Global styles={GlobalStyle(THEME['dark'])} />
+          <button
+            onClick={open}
+            style={{
+              backgroundColor: 'lightblue',
+              padding: '5px',
+              borderRadius: '5px'
+            }}>
+            Modal 오픈
+          </button>
+          <Modal
+            isOpen={isOpen}
+            close={close}
+            isAnimating={isAnimating}>
+            <div>안녕하세요</div>
+            <div>하이하이복실</div>
+          </Modal>
+        </ThemeProvider>
+      </div>
     )
-    }
+  }
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - close #number -->

- close #24 

## ✅ 작업 내용

- `useModal`에 조건부 렌더링 추가
- `useModa`l의 `Modal`에 `width`와 `height` 변경 가능하도록 `props`  추가
- 조건부 렌더링으로 적용이 안되던 `transition`적용을 위해 `setTimeout`사용
- Modal `open`을 연타 실행시 Modal 상태가 꼬이던 문제를 `isLoading`으로 처리

### 다중 모달 시연 영상
https://github.com/oridori2705/Herbs-Or-weeds/assets/90139306/aa06ddfe-96d6-46bf-bef5-6989cd265efe

### Modal 사용 컴포넌트의 리-렌더링시 Modal도 모두 리-렌더링 되는 상

https://github.com/oridori2705/Herbs-Or-weeds/assets/90139306/efe23b29-bd8c-49da-8274-94a411549e96

- 일단 Modal 내에서 state를 변경해 리-렌더링을 일으키는 상황이 없음
- Modal내에서 state를 변경시 같이 리-렌더링 되어 최신화된 데이터를 가져올 수 있으므로 장점도 분명 존재
- 하지만 결과적으로 Modal이 불필요하게 리-렌더링 되므로 추후 Context API를 이용하여 해결 가능함을 발견
- 블로그에 context API로 useModal을 구현했음 -> 필요시 사용

## 📝 참고 자료

 - [useModal 트러블 슈팅](https://ydoag2003.tistory.com/463)

## ♾️ 기타

[Reflow와 Repaint](https://velog.io/@leitmotif/%EB%86%93%EC%B9%98%EA%B8%B0-%EC%89%AC%EC%9A%B4-reflow-repaint)
[Layer Model에 대해](https://ssocoit.tistory.com/259#0.1._Graphics_Layer)