### PR TITLE
fix: undici 버전 override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16595,9 +16595,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
-      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "@vercel/node": {
       "ts-node": "10.9.1",
       "typescript": "5.4.5"
-    }
+    },
+    "undici": "^5.28.4"
   },
   "readme": "ERROR: No README data found!",
   "_id": "herbs-or-weeds@0.0.0"


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - close #number -->

- close #30 

## ✅ 작업 내용
[Dependabot alerts](https://github.com/oridori2705/Herbs-Or-weeds/security/dependabot) 
[#14](https://github.com/oridori2705/Herbs-Or-weeds/security/dependabot/14) 
[#13](https://github.com/oridori2705/Herbs-Or-weeds/security/dependabot/13)
[#12](https://github.com/oridori2705/Herbs-Or-weeds/security/dependabot/12)
<br/>

- undici로 인한 취약점 문제 해결
- undici 버전 5.26.5 -> 5.28.4로 override
- 아래와 같이 취약점 제거
![image](https://github.com/oridori2705/Herbs-Or-weeds/assets/90139306/cde034a9-2f13-46c5-b828-2b8788c2da4e)


## 📝 참고 자료

[현재 undici 버전](https://www.npmjs.com/package/undici)
[현재 vercel 버전](https://www.npmjs.com/package/vercel)

## ♾️ 기타
[해당 내용 블로그에 정리했습니다!](https://ydoag2003.tistory.com/473)