### PR TITLE
fix: br태그 replace로 데이터 정제

### DIFF
--- a/src/pages/CardDetail/CardDetail.styled.ts
+++ b/src/pages/CardDetail/CardDetail.styled.ts
@@ -38,6 +38,7 @@ export const InfoItem = styled.p`
   margin: 5px 0;
   font-size: 16px;
   color: #555;
+  white-space: pre-wrap;
 `
 
 export const SectionTitle = styled.h2`
@@ -50,4 +51,5 @@ export const Description = styled.p`
   font-size: 16px;
   color: #333;
   line-height: 1.5;
+  white-space: pre-wrap;
 `

--- a/src/pages/CardDetail/index.tsx
+++ b/src/pages/CardDetail/index.tsx
@@ -20,6 +20,10 @@ const CardDetail = () => {
   const { pictureId } = useParams()
   const { data, isFetching, isSuccess } = useGetHerbDetail(Number(pictureId))
 
+  const replaceBrTags = (description: string) => {
+    const formattedText = description.replace(/<br\s*\/?>/g, '\n')
+    return formattedText
+  }
   useEffect(() => {
     open()
   }, [])
@@ -67,12 +71,12 @@ const CardDetail = () => {
               <InfoItem>학명: {data.bneNm}</InfoItem>
               <InfoItem>생약명: {data.hbdcNm}</InfoItem>
               <InfoItem>이용부위: {data.useeRegn}</InfoItem>
-              <InfoItem>형태: {data.stle}</InfoItem>
+              <InfoItem>형태: {replaceBrTags(data.stle)}</InfoItem>
             </InfoSection>
 
             <InfoSection>
               <SectionTitle>민간요법</SectionTitle>
-              <Description>{data.prvateTherpy}</Description>
+              <Description>{replaceBrTags(data.prvateTherpy)}</Description>
             </InfoSection>
           </Container>
         ) : (


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - close #number -->

- close #33

## ✅ 작업 내용

### 1.  받아오는 데이터에 존재하는 <br/>태그 제거 후 줄바꿈으로 대체 
- `pre` 태그를 사용하면 replace가 필요없지만 다른 요소의 스타일 일관성을 위해 `p`태그 사용 
- `p`태그에 `white-space : pre-wrap`사용
![image](https://github.com/user-attachments/assets/1dc1942a-a350-4761-b50f-c78f2e745e39)

